### PR TITLE
Update HiveMetaStoreClient.java

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -273,7 +273,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient {
         // make metastore URIS random
         List uriList = Arrays.asList(metastoreUris);
         Collections.shuffle(uriList);
-        metastoreUris = (URI[]) uriList.toArray();
+        metastoreUris = uriList.toArray(metastoreUris);
       } catch (IllegalArgumentException e) {
         throw (e);
       } catch (Exception e) {


### PR DESCRIPTION
Bug fix --> message:Got exception: java.lang.ClassCastException [Ljava.lang.Object; incompatible with [Ljava.net.URI;)

Detecting when try to run HiveSourceConnector ( https://docs.lenses.io/connectors/source/hive.html ) on Kafka connect cluster